### PR TITLE
ci: add validate gate, automatic release, and shared renovate preset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
+      - run: tofu fmt -check -recursive
+      - run: tofu init -backend=false
+      - run: tofu validate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+concurrency: release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - id: tag
+        uses: mathieudutour/github-tag-action@v6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+      - uses: softprops/action-gh-release@v2
+        if: steps.tag.outputs.new_tag
+        with:
+          tag_name: ${{ steps.tag.outputs.new_tag }}
+          body: ${{ steps.tag.outputs.changelog }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "platformAutomerge": true,
-  "automergeStrategy": "squash",
-  "packageRules": [
-    {
-      "description": "Automerge all updates including major",
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "automerge": true
-    }
-  ]
+  "extends": ["github>lexfrei/renovate-config"]
 }


### PR DESCRIPTION
Wire up automatic dependency handling for this module:

- **CI** (`ci.yaml`): a `pull_request` job runs `tofu fmt -check`, `tofu init -backend=false` and `tofu validate` — catches breaking provider bumps and gives auto-merge a required check to gate on.
- **Release** (`release.yaml`): tags the next patch version on every push to `master`, so the Terraform Registry publishes a new module version automatically once a change lands.
- **Renovate**: extend the shared `github>lexfrei/renovate-config` preset. Minor/patch provider updates auto-merge and cut a release; major bumps now land as a reviewable PR (previously everything auto-merged, including major).

This makes Cloudflare provider bumps flow through automatically and keeps the published module version in lockstep — which is what downstream consumers pin against.